### PR TITLE
バグを修正

### DIFF
--- a/mahjongsoul_sniffer/s3.py
+++ b/mahjongsoul_sniffer/s3.py
@@ -77,7 +77,7 @@ class Bucket:
 
     def get_game_abstracts(self, max_keys: int=1000) -> List[dict]:
         key_prefix = self.__config['game_abstract_key_prefix']
-        key_prefix = re.sub('/*$', '', key_prefix)
+        key_prefix = key_prefix.rstrip('/') + '/'
 
         # https://github.com/boto/boto3/issues/2186
         game_abstract_objects = self.__bucket.objects.filter(


### PR DESCRIPTION
S3 のプレフィックスでオブジェクトのリストをフィルタする際に，
プレフィックスの最後に "/" を付けるように修正した．この修正により，
例えば "game-abstract" をプレフィックスとして指定した時に
"game-abstract-alcyone" や "game-abstract-electra" 等をプレフィックスと
するオブジェクトが除かれるようになった．