### PR TITLE
Changed to restart Game Abstract Crawler when an error occurs

### DIFF
--- a/game-abstract-crawler/config.yaml
+++ b/game-abstract-crawler/config.yaml
@@ -29,6 +29,7 @@ archiver:
       key: log.archiver
       max_entries: 100
 crawler:
+  retry_interval: 300
   logging:
     level: INFO
     file:

--- a/game-abstract-crawler/crawler.py
+++ b/game-abstract-crawler/crawler.py
@@ -17,9 +17,13 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver import ActionChains
+import mahjongsoul_sniffer.config as config_
 import mahjongsoul_sniffer.logging as logging_
 import mahjongsoul_sniffer.redis as redis_
 from mahjongsoul_sniffer.yostar_login import YostarLogin
+
+
+_CONFIG = config_.get('game_abstract_crawler')['crawler']
 
 
 class RefreshRequest(Exception):
@@ -304,23 +308,28 @@ if __name__ == '__main__':
     logging_.initialize(module_name='game_abstract_crawler',
                         service_name='crawler')
 
-    options = Options()
-    options.headless = True
-    options.add_argument('--no-sandbox')
-    options.add_argument('--disable-dev-shm-usage')
-    options.add_argument('--window-size=800,600')
+    while True:
+        options = Options()
+        options.headless = True
+        options.add_argument('--no-sandbox')
+        options.add_argument('--disable-dev-shm-usage')
+        options.add_argument('--window-size=800,600')
 
-    proxy = Proxy()
-    proxy.http_proxy = 'localhost:8080'
-    proxy.https_proxy = 'localhost:8080'
-    capabilities = DesiredCapabilities.CHROME
-    proxy.add_to_capabilities(capabilities)
+        proxy = Proxy()
+        proxy.http_proxy = 'localhost:8080'
+        proxy.https_proxy = 'localhost:8080'
+        capabilities = DesiredCapabilities.CHROME
+        proxy.add_to_capabilities(capabilities)
 
-    with Chrome(options=options,
-                desired_capabilities=capabilities) as driver:
-        try:
-            main(driver)
-        except Exception as e:
-            _get_screenshot(driver, '99-エラー.png')
-            logging.exception('Abort with an unhandled exception.')
-            raise
+        with Chrome(options=options,
+                    desired_capabilities=capabilities) as driver:
+            try:
+                main(driver)
+                break
+            except Exception as e:
+                _get_screenshot(driver, '99-エラー.png')
+                logging.exception('Abort with an unhandled exception.')
+
+        logging.info(
+            f'''Sleep for {_CONFIG['retry_interval']} seconds.''')
+        time.sleep(_CONFIG['retry_interval'])

--- a/mahjongsoul_sniffer/game_abstract_crawler/config.py
+++ b/mahjongsoul_sniffer/game_abstract_crawler/config.py
@@ -159,9 +159,14 @@ _CONFIG_SCHEMA = {
         'crawler': {
             'type': 'object',
             'required': [
+                'retry_interval',
                 'logging'
             ],
             'properties': {
+                'retry_interval': {
+                    'type': 'integer',
+                    'minimum': 0
+                },
                 'logging': _LOGGING_CONFIG_SCHEMA
             },
             'additionalProperties': False


### PR DESCRIPTION
* game-abstract-crawler/config.yaml: Add the `crawler.retry_interval`
  key.
* game-abstract-crawler/crawler.py: Changed to restart the Game
  Abstract Crawler after a configured interval when an error occurs.
  This eliminates needs to manually restart the Game Abstract Crawler
  after maintenance on MahjongSoul.
* mahjongsoul_sniffer/game_abstract_crawler/config.py: Changed to
  verify the `crawler.retry_interval` key.
* mahjongsoul_sniffer/yostar_login.py: When a crawler tries obtaining
  an authentication code to log in to MahjongSoul, E-mails containing
  an authentication code are deleted.  However, until this commit, even
  E-mails that are not addressed to the crawler are deleted.  This
  logic may accidentally delete an E-mail that were originally
  necessary for another crawler if multiple crawlers start login at the
  nearly same time.  This commit fixes this problem.