### PR TITLE
Add support for date difference between abstract and detail

### DIFF
--- a/mahjongsoul_sniffer/s3.py
+++ b/mahjongsoul_sniffer/s3.py
@@ -123,10 +123,26 @@ class Bucket:
         game_detail_object = self.__bucket.Object(key)
         try:
             game_detail_object.load()
+            return True
         except botocore.exceptions.ClientError as e:
-            return False
+            pass
 
-        return True
+        start_time += datetime.timedelta(days=1)
+
+        key_prefix = self.__config['game_detail_key_prefix']
+        key_prefix = re.sub('/*$', '', key_prefix)
+        key_prefix = start_time.strftime(key_prefix)
+
+        key = f'{key_prefix}/{uuid}'
+
+        game_detail_object = self.__bucket.Object(key)
+        try:
+            game_detail_object.load()
+            return True
+        except botocore.exceptions.ClientError as e:
+            pass
+
+        return False
 
     def put_game_detail(self, message: bytes) -> None:
         game_abstract = game_detail_.get_game_abstract(message)


### PR DESCRIPTION
For games that start at around 9:00 JST every day, it often happens that
the time recorded in abstract is just before 9:00 JST and the time
recorded in detail is just after 9:00 JST, even though the UUID of the
game is the same.  As a result, the S3 key prefixes of abstract and
detail of a game with the same UUID may be different, i.e., the S3 key
prefix of detail may be one day after the key prefix of abstract.  This
commit adds support for such situation.