### PR TITLE
Fix/fix ubuntu version to jammy

### DIFF
--- a/api-visualizer/build.Dockerfile
+++ b/api-visualizer/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       curl \

--- a/api-visualizer/web-server.Dockerfile
+++ b/api-visualizer/web-server.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && apt-get install -y \
       protobuf-compiler \

--- a/crawler-batch/build.Dockerfile
+++ b/crawler-batch/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && \
     apt-get -y dist-upgrade && \

--- a/crawler-batch/main.Dockerfile
+++ b/crawler-batch/main.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && \
     apt-get -y dist-upgrade && \

--- a/crawler-batch/monitor.Dockerfile
+++ b/crawler-batch/monitor.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && \
     apt-get -y dist-upgrade && \

--- a/game-abstract-crawler/archiver.Dockerfile
+++ b/game-abstract-crawler/archiver.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && apt-get install -y \
       python3 \

--- a/game-abstract-crawler/build.Dockerfile
+++ b/game-abstract-crawler/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       curl \

--- a/game-abstract-crawler/crawler.Dockerfile
+++ b/game-abstract-crawler/crawler.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 SHELL ["/bin/bash", "-c"]
 

--- a/game-abstract-crawler/monitor.Dockerfile
+++ b/game-abstract-crawler/monitor.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && apt-get install -y \
       python3 \

--- a/game-detail-crawler/archiver.Dockerfile
+++ b/game-detail-crawler/archiver.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && apt-get install -y \
       python3 \

--- a/game-detail-crawler/build.Dockerfile
+++ b/game-detail-crawler/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       curl \

--- a/game-detail-crawler/crawler.Dockerfile
+++ b/game-detail-crawler/crawler.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && apt-get install -y \
       ca-certificates \

--- a/game-detail-crawler/monitor.Dockerfile
+++ b/game-detail-crawler/monitor.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && apt-get install -y \
       python3 \


### PR DESCRIPTION
## 概要

Dockerfile 内の ubuntu のバージョン指定を latest から jammy (22.04) に変更します。

## 理由

2024-04-30 現在 latest は noble (24.04) を指しています。
noble では デフォルトのユーザーに `ubuntu` が追加されたため、`useradd -ms /bin/bash ubuntu` がエラーとなりビルドが失敗します。

回避策として、一旦問題の発生しない jammy (22.04) にバージョンを固定します。
noble (24.04) への対応は別途行います。

## 備考

#100 Refactor/lint and format with Ruff から本ブランチを切ったため、#100 の master へのマージが完了するまでは Draft にします。